### PR TITLE
Fix error caused by change on Atom API

### DIFF
--- a/lib/scroll-sync.coffee
+++ b/lib/scroll-sync.coffee
@@ -75,7 +75,7 @@ class ScrlSync
       disposables.add buffer.onDidStopChanging => @textChanged()
 
       # And, of course, follow the scrolling !
-      disposables.add editor.onDidChangeScrollTop => @scrollPosChanged i
+      disposables.add editorEle.onDidChangeScrollTop => @scrollPosChanged i
 
     # Initialise the correlation map, and do not try to follow insertions if the files are too much different
     @simpleScroll = @textChanged()


### PR DESCRIPTION
A change on the Atom API move the function onDidChangeScrollTop from editor to editorEle. Here is the quick fix. Now the package works with the newest Atom version.