### PR TITLE
change status bar element to icon

### DIFF
--- a/lib/scroll-sync.coffee
+++ b/lib/scroll-sync.coffee
@@ -207,7 +207,7 @@ class ScrlSync
 
   deactivate: ->
     # Stop the scroll triggers
-    @stopTracking()
+    @stopTracking() if @tracking
 
     # Remove our item in the status bar
     @statusBarTooltip?.dispose()

--- a/lib/scroll-sync.coffee
+++ b/lib/scroll-sync.coffee
@@ -12,15 +12,15 @@ class ScrlSync
 
   activate: (state) ->
     @tracking = no
-    @paneDisposables = new CompositeDisposable
+    @disposables = new CompositeDisposable
 
-    atom.commands.add 'atom-workspace', 'scroll-sync:toggle': =>
+    @disposables.add atom.commands.add 'atom-workspace', 'scroll-sync:toggle': =>
       @toggleTracking()
 
-    @paneDisposables.add atom.workspace.getCenter().onDidAddPane =>
+    @disposables.add atom.workspace.getCenter().onDidAddPane =>
       @checkPaneCount()
 
-    @paneDisposables.add atom.workspace.getCenter().onDidDestroyPane =>
+    @disposables.add atom.workspace.getCenter().onDidDestroyPane =>
       @checkPaneCount()
 
     @checkPaneCount()
@@ -67,7 +67,7 @@ class ScrlSync
       @stopTracking()
       return
 
-    @disposables = new CompositeDisposable
+    @trackingDisposables = new CompositeDisposable
     @paneInfo = []
 
     @addPaneInfo pane for pane in panes
@@ -104,13 +104,13 @@ class ScrlSync
     ## Set the triggers
 
     # Stop tracking if the pane is closed
-    @disposables.add pane.onWillDestroy => @stopTracking()
+    @trackingDisposables.add pane.onWillDestroy => @stopTracking()
 
     # Keep tracking the changes
-    @disposables.add buffer.onDidStopChanging => @textChanged()
+    @trackingDisposables.add buffer.onDidStopChanging => @textChanged()
 
     # And, of course, follow the scrolling !
-    @disposables.add editorEle.onDidChangeScrollTop => @scrollPosChanged i
+    @trackingDisposables.add editorEle.onDidChangeScrollTop => @scrollPosChanged i
 
 
   textChanged: ->
@@ -202,8 +202,8 @@ class ScrlSync
     @simpleScroll = false
 
     # Clear the triggers
-    @disposables.dispose()
-    @disposables.clear()
+    @trackingDisposables.dispose()
+    @trackingDisposables.clear()
 
   deactivate: ->
     # Stop the scroll triggers
@@ -216,7 +216,7 @@ class ScrlSync
     @statusBarTile = null
     @statusBarEle = null
 
-    @paneDisposables.dispose()
-    @paneDisposables.clear()
+    @disposables.dispose()
+    @disposables.clear()
 
 module.exports = new ScrlSync

--- a/package.json
+++ b/package.json
@@ -10,11 +10,6 @@
       }
     }
   },
-  "activationCommands": {
-    "atom-text-editor": [
-      "scroll-sync:toggle"
-    ]
-  },
   "author": {
     "name": "Mark Hahn",
     "url": "https://github.com/mark-hahn"

--- a/package.json
+++ b/package.json
@@ -11,33 +11,35 @@
     }
   },
   "activationCommands": {
-    "atom-text-editor": ["scroll-sync:toggle"]
+    "atom-text-editor": [
+      "scroll-sync:toggle"
+    ]
   },
   "author": {
-    "name" : "Mark Hahn",
-    "url" : "https://github.com/mark-hahn"
+    "name": "Mark Hahn",
+    "url": "https://github.com/mark-hahn"
   },
   "contributors": [
     {
-      "name" : "George Brindeiro",
-      "url" : "https://github.com/georgebrindeiro"
+      "name": "George Brindeiro",
+      "url": "https://github.com/georgebrindeiro"
     },
     {
-      "name" : "Thomas P.",
-      "url" : "https://github.com/TPXP"
+      "name": "Thomas P.",
+      "url": "https://github.com/TPXP"
     },
     {
-      "name" : "Filipe Augusto Miranda",
-      "url" : "https://github.com/kinetoskombi"
+      "name": "Filipe Augusto Miranda",
+      "url": "https://github.com/kinetoskombi"
     },
     {
-      "name" : "laslojuly",
-      "url" : "https://github.com/lazlojuly"
+      "name": "laslojuly",
+      "url": "https://github.com/lazlojuly"
     }
   ],
   "repository": {
-      "type": "git",
-      "url": "https://github.com/georgebrindeiro/scroll-sync"
+    "type": "git",
+    "url": "https://github.com/georgebrindeiro/scroll-sync"
   },
   "bugs": {
     "url": "https://github.com/georgebrindeiro/scroll-sync/issues"
@@ -47,7 +49,6 @@
     "atom": ">0.170.0"
   },
   "dependencies": {
-    "diff_match_patch": "0.1.x",
-    "status-bar": "^2.0.3"
+    "diff_match_patch": "0.1.x"
   }
 }

--- a/styles/scroll-sync.less
+++ b/styles/scroll-sync.less
@@ -1,0 +1,23 @@
+@import "ui-variables";
+
+.scroll-sync-status-bar {
+	display: none;
+
+	&::before {
+		content: "⇕";
+	}
+
+	&.two-panes {
+		display: inline-block;
+	}
+
+	&.scroll-sync-on {
+		display: inline-block;
+		color: @text-color-success;
+
+		&::before {
+			font-weight: bold;
+			content: "⬍";
+		}
+	}
+}


### PR DESCRIPTION
This pull request has a few different things in it.

 1. `status-bar` dependency is not used and not needed to consume the atom status bar service
 2. Changed the status bar element to an icon with a tooltip that will only show when two panes are open and will automatically hide if one is removed or more than two are open
 3. Allows the status bar to toggle `scroll-sync` on and off
 4. Removed the `activationCommands` parameter from `package.json` to allow the status bar icon to show before the user turns `scroll-sync` on